### PR TITLE
Optionally include constraint property metadata in statistical observation DataFrames 

### DIFF
--- a/datacommons_client/client.py
+++ b/datacommons_client/client.py
@@ -6,6 +6,7 @@ from datacommons_client.endpoints.observation import ObservationEndpoint
 from datacommons_client.endpoints.resolve import ResolveEndpoint
 from datacommons_client.models.observation import ObservationDate
 from datacommons_client.utils.dataframes import add_entity_names_to_observations_dataframe
+from datacommons_client.utils.dataframes import add_property_constraints_to_observations_dataframe
 from datacommons_client.utils.decorators import requires_pandas
 from datacommons_client.utils.error_handling import NoDataForPropertyError
 
@@ -92,7 +93,8 @@ class DataCommonsClient:
           date=date,
           entity_dcids=entity_dcids,
           variable_dcids=variable_dcids,
-          select=["variable", "entity", "facet"])
+          select=["variable", "entity", "facet"],
+      )
     else:
       observations = self.observation.fetch_observations_by_entity_type(
           date=date,
@@ -120,6 +122,7 @@ class DataCommonsClient:
       entity_type: Optional[str] = None,
       parent_entity: Optional[str] = None,
       property_filters: Optional[dict[str, str | list[str]]] = None,
+      include_constraints_metadata: bool = False,
   ):
     """
         Fetches statistical observations and returns them as a Pandas DataFrame.
@@ -139,6 +142,8 @@ class DataCommonsClient:
             Required if `entity_dcids="all"`. Defaults to None.
         property_filters (Optional[dict[str, str | list[str]]): An optional dictionary used to filter
             the data by using observation properties like `measurementMethod`, `unit`, or `observationPeriod`.
+        include_constraints_metadata (bool): If True, includes the dcid and name of any constraint
+            properties associated with the variable DCIDs in the returned DataFrame. Defaults to False.
 
         Returns:
             pd.DataFrame: A DataFrame containing the requested observations.
@@ -181,7 +186,8 @@ class DataCommonsClient:
           date=date,
           entity_dcids=entity_dcids,
           variable_dcids=variable_dcids,
-          filter_facet_ids=facets)
+          filter_facet_ids=facets,
+      )
 
     # Convert the observations to a DataFrame
     df = pd.DataFrame(observations.to_observation_records().model_dump())
@@ -192,5 +198,11 @@ class DataCommonsClient:
         observations_df=df,
         entity_columns=["entity", "variable"],
     )
+
+    if include_constraints_metadata:
+      df = add_property_constraints_to_observations_dataframe(
+          endpoint=self.node,
+          observations_df=df,
+      )
 
     return df

--- a/datacommons_client/client.py
+++ b/datacommons_client/client.py
@@ -143,7 +143,8 @@ class DataCommonsClient:
         property_filters (Optional[dict[str, str | list[str]]): An optional dictionary used to filter
             the data by using observation properties like `measurementMethod`, `unit`, or `observationPeriod`.
         include_constraints_metadata (bool): If True, includes the dcid and name of any constraint
-            properties associated with the variable DCIDs in the returned DataFrame. Defaults to False.
+            properties associated with the variable DCIDs (based on the `constraintProperties` property)
+            in the returned DataFrame. Defaults to False.
 
         Returns:
             pd.DataFrame: A DataFrame containing the requested observations.

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -11,6 +11,8 @@ from datacommons_client.endpoints.payloads import normalize_list_to_string
 from datacommons_client.endpoints.response import NodeResponse
 from datacommons_client.models.node import Name
 from datacommons_client.models.node import Node
+from datacommons_client.models.node import StatVarConstraint
+from datacommons_client.models.node import StatVarConstraints
 from datacommons_client.utils.graph import build_graph_map
 from datacommons_client.utils.graph import build_relationship_tree
 from datacommons_client.utils.graph import fetch_relationship_lru
@@ -534,3 +536,106 @@ class NodeEndpoint(Endpoint):
         relationship="children",
         max_concurrent_requests=max_concurrent_requests,
     )
+
+  def _fetch_property_id_names(self, node_dcids: str | list[str],
+                               properties: str | list[str]):
+    """Fetch target nodes for given properties and return only (dcid, name).
+
+        For each input node and each requested property, returns the list of target
+        nodes as dictionaries with ``dcid`` and ``name``.
+
+        Args:
+            node_dcids: A single DCID or a list of DCIDs to query.
+            properties: A property string or list of property strings.
+
+        Returns:
+            A mapping:
+            `{ node_dcid: { property: [ {dcid, name}, ... ], ... }, ... }`.
+        """
+    data = self.fetch_property_values(node_dcids=node_dcids,
+                                      properties=properties).get_properties()
+
+    result: dict[str, dict[str, list[dict]]] = {}
+
+    for node, props in data.items():
+      result.setdefault(node, {})
+      for prop, metadata in props.items():
+        dest = result[node].setdefault(prop, [])
+        for n in metadata:
+          dest.append({"dcid": n.dcid, "name": n.name})
+    return result
+
+  def fetch_statvar_constraints(
+      self, variable_dcids: str | list[str]) -> StatVarConstraints:
+    """Fetch constraint property/value pairs for statistical variables.
+
+        This returns, for each StatisticalVariable, the constraints that define it.
+
+        Args:
+            variable_dcids: One or more StatisticalVariable DCIDs.
+
+        Returns:
+            StatVarConstraints:
+            ``{
+                <sv_dcid>: [
+                    {
+                        "constraint_id": <constraint_property_dcid>,
+                        "constraint_name": <constraint_property_name>,
+                        "value_id": <value_node_dcid>,
+                        "value_name": <value_node_name>,
+                    },
+                    ...
+                ],
+                ...
+            }``
+        """
+    # Ensure variable_dcids is a list
+    if isinstance(variable_dcids, str):
+      variable_dcids = [variable_dcids]
+
+    # Get constraints for the given variable DCIDs.
+    constraints_mapping = self._fetch_property_id_names(
+        node_dcids=variable_dcids, properties=["constraintProperties"])
+
+    # Per statvar mapping of dcid - name
+    per_sv_constraint_names = {}
+    # Global set of all constraint property IDs
+    all_constraint_prop_ids = set()
+
+    for sv in variable_dcids:
+      # Get the constraint properties for this statvar
+      prop_entries = constraints_mapping.get(sv,
+                                             {}).get("constraintProperties", [])
+      # Map the constraint properties to their names
+      id_to_name = {entry["dcid"]: entry.get("name") for entry in prop_entries}
+      # Add an entry for this statvar to the constraint names mapping
+      per_sv_constraint_names[sv] = id_to_name
+      # Update the global set of all constraint property IDs
+      all_constraint_prop_ids.update(id_to_name.keys())
+
+    # In a single request, fetch all values for all the constraints, for all statvars.
+    values_map = self._fetch_property_id_names(
+        node_dcids=variable_dcids,
+        properties=sorted(all_constraint_prop_ids),
+    )
+
+    # Build structured response. This will include vars with no constraints (empty dicts).
+    result = {sv: [] for sv in variable_dcids}
+
+    for sv in variable_dcids:
+      constraint_names = per_sv_constraint_names.get(sv, {})
+      sv_values = values_map.get(sv, {})
+
+      for constraint_id, constraint_name in constraint_names.items():
+        values = sv_values.get(constraint_id, [])
+
+        # Build the StatVarConstraint object
+        result[sv].append(
+            StatVarConstraint(
+                constraint_id=constraint_id,
+                constraint_name=constraint_name,
+                value_id=values[0]["dcid"],
+                value_name=values[0].get("name"),
+            ))
+
+    return StatVarConstraints.model_validate(result)

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -632,8 +632,8 @@ class NodeEndpoint(Endpoint):
       constraint_names = per_sv_constraint_names.get(sv, {})
       sv_values = values_map.get(sv, {})
 
-      for constraint_id, constraint_name in constraint_names.items():
-        values = sv_values.get(constraint_id, [])
+      for constraintId, constraintName in constraint_names.items():
+        values = sv_values.get(constraintId, [])
         # Continue if the stat var doesn't actually define a value for one of its constraintProperties.
         if not values:
           continue
@@ -641,10 +641,10 @@ class NodeEndpoint(Endpoint):
         # Build the StatVarConstraint object
         result[sv].append(
             StatVarConstraint(
-                constraint_id=constraint_id,
-                constraint_name=constraint_name,
-                value_id=values[0]["dcid"],
-                value_name=values[0].get("name"),
+                constraintId=constraintId,
+                constraintName=constraintName,
+                valueId=values[0]["dcid"],
+                valueName=values[0].get("name"),
             ))
 
     return StatVarConstraints.model_validate(result)

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -564,7 +564,10 @@ class NodeEndpoint(Endpoint):
       for prop, metadata in props.items():
         dest = result[node].setdefault(prop, [])
         for n in metadata:
-          dest.append({"dcid": n.dcid, "name": n.name})
+          # Prefer 'dcid', but if property is terminal, fall back to 'value'.
+          dcid = n.dcid or n.value
+          name = n.name or n.value
+          dest.append({"dcid": dcid, "name": name})
     return result
 
   def fetch_statvar_constraints(
@@ -631,6 +634,9 @@ class NodeEndpoint(Endpoint):
 
       for constraint_id, constraint_name in constraint_names.items():
         values = sv_values.get(constraint_id, [])
+        # Continue if the stat var doesn't actually define a value for one of its constraintProperties.
+        if not values:
+          continue
 
         # Build the StatVarConstraint object
         result[sv].append(

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -25,6 +25,8 @@ from datacommons_client.utils.names import NAME_WITH_LANGUAGE_PROPERTY
 
 PLACES_MAX_WORKERS = 10
 
+CONSTRAINT_PROPERTY: str = "constraintProperties"
+
 _DEPRECATED_METHODS: dict[str, dict[str, str | dict[str, str]]] = {
     "fetch_entity_parents": {
         "new_name": "fetch_place_parents",
@@ -567,7 +569,8 @@ class NodeEndpoint(Endpoint):
 
   def fetch_statvar_constraints(
       self, variable_dcids: str | list[str]) -> StatVarConstraints:
-    """Fetch constraint property/value pairs for statistical variables.
+    """Fetch constraint property/value pairs for statistical variables, using
+        the `constraintProperties` property.
 
         This returns, for each StatisticalVariable, the constraints that define it.
 
@@ -595,7 +598,7 @@ class NodeEndpoint(Endpoint):
 
     # Get constraints for the given variable DCIDs.
     constraints_mapping = self._fetch_property_id_names(
-        node_dcids=variable_dcids, properties=["constraintProperties"])
+        node_dcids=variable_dcids, properties=[CONSTRAINT_PROPERTY])
 
     # Per statvar mapping of dcid - name
     per_sv_constraint_names = {}
@@ -605,7 +608,7 @@ class NodeEndpoint(Endpoint):
     for sv in variable_dcids:
       # Get the constraint properties for this statvar
       prop_entries = constraints_mapping.get(sv,
-                                             {}).get("constraintProperties", [])
+                                             {}).get(CONSTRAINT_PROPERTY, [])
       # Map the constraint properties to their names
       id_to_name = {entry["dcid"]: entry.get("name") for entry in prop_entries}
       # Add an entry for this statvar to the constraint names mapping

--- a/datacommons_client/models/node.py
+++ b/datacommons_client/models/node.py
@@ -90,3 +90,20 @@ class NodeList(BaseDCModel, ListLikeRootModel[list[Node]]):
 
 class NodeDCIDList(BaseDCModel, ListLikeRootModel[list[NodeDCID]]):
   """A root model whose value is a list of NodeDCID strings."""
+
+
+class StatVarConstraint(BaseDCModel):
+  """Represents a constraint for a statistical variable."""
+
+  constraint_id: NodeDCID
+  constraint_name: Optional[str] = None
+  value_id: NodeDCID
+  value_name: Optional[str] = None
+
+
+class StatVarConstraints(BaseDCModel,
+                         DictLikeRootModel[dict[NodeDCID,
+                                                list[StatVarConstraint]]]):
+  """A root model whose value is a dictionary of statvar ids - a list of StatVarConstraint objects.
+    This model is used to represent constraints associated with statistical variables.
+    """

--- a/datacommons_client/models/node.py
+++ b/datacommons_client/models/node.py
@@ -95,10 +95,10 @@ class NodeDCIDList(BaseDCModel, ListLikeRootModel[list[NodeDCID]]):
 class StatVarConstraint(BaseDCModel):
   """Represents a constraint for a statistical variable."""
 
-  constraint_id: NodeDCID
-  constraint_name: Optional[str] = None
-  value_id: NodeDCID
-  value_name: Optional[str] = None
+  constraintId: NodeDCID
+  constraintName: Optional[str] = None
+  valueId: NodeDCID
+  valueName: Optional[str] = None
 
 
 class StatVarConstraints(BaseDCModel,

--- a/datacommons_client/tests/endpoints/test_node_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_node_endpoint.py
@@ -482,7 +482,7 @@ def test_fetch_statvar_constraints_builds_constraints_and_values():
   assert "sv/1" in result
   # Two constraints returned
   assert len(result["sv/1"]) == 2
-  ids = {(c.constraint_id, c.value_id) for c in result["sv/1"]}
+  ids = {(c.constraintId, c.valueId) for c in result["sv/1"]}
   assert ids == {("p1", "v1"), ("p2", "v2")}
 
 
@@ -562,5 +562,5 @@ def test_fetch_statvar_constraints_skips_missing_constraint_values():
   assert "sv/1" in result
   # Only one well-formed constraint should be included (p1)
   assert len(result["sv/1"]) == 1
-  assert result["sv/1"][0].constraint_id == "p1"
-  assert result["sv/1"][0].value_id == "v1"
+  assert result["sv/1"][0].constraintId == "p1"
+  assert result["sv/1"][0].valueId == "v1"

--- a/datacommons_client/tests/endpoints/test_node_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_node_endpoint.py
@@ -514,9 +514,7 @@ def test__fetch_property_id_names_handles_literal_values():
   endpoint.fetch_property_values = MagicMock(return_value=NodeResponse(
       data={
           "sv/1":
-              Arcs(arcs={
-                  "p1": NodeGroup(nodes=[Node(value="LiteralValue")])
-              })
+              Arcs(arcs={"p1": NodeGroup(nodes=[Node(value="LiteralValue")])})
       }))
 
   result = endpoint._fetch_property_id_names("sv/1", "p1")
@@ -553,15 +551,7 @@ def test_fetch_statvar_constraints_skips_missing_constraint_values():
   }
 
   # p1 has a value, p2 is missing/empty
-  values_map = {
-      "sv/1": {
-          "p1": [{
-              "dcid": "v1",
-              "name": "Val One"
-          }],
-          "p2": []
-      }
-  }
+  values_map = {"sv/1": {"p1": [{"dcid": "v1", "name": "Val One"}], "p2": []}}
 
   with patch.object(endpoint,
                     "_fetch_property_id_names",

--- a/datacommons_client/tests/models/test_node_models.py
+++ b/datacommons_client/tests/models/test_node_models.py
@@ -2,6 +2,8 @@ from datacommons_client.models.node import Arcs
 from datacommons_client.models.node import Node
 from datacommons_client.models.node import NodeGroup
 from datacommons_client.models.node import Properties
+from datacommons_client.models.node import StatVarConstraint
+from datacommons_client.models.node import StatVarConstraints
 
 
 def test_node_model_validation():
@@ -108,3 +110,44 @@ def test_properties_model_validation_empty():
   json_data = {}
   properties = Properties.model_validate(json_data)
   assert properties.properties is None
+
+
+def test_statvarconstraint_model_validation():
+  """Test StatVarConstraint.model_validate parses data correctly."""
+  data = {
+      "constraint_id": "DevelopmentFinanceScheme",
+      "constraint_name": "Development Finance Scheme",
+      "value_id": "ODAGrants",
+      "value_name": "Official Development Assistance Grants",
+  }
+  constraint = StatVarConstraint.model_validate(data)
+
+  assert constraint.constraint_id == "DevelopmentFinanceScheme"
+  assert constraint.constraint_name == "Development Finance Scheme"
+  assert constraint.value_id == "ODAGrants"
+  assert constraint.value_name == "Official Development Assistance Grants"
+
+
+def test_statvarconstraints_model_validation():
+  """Test StatVarConstraints root model validates mapping properly."""
+  constraints = StatVarConstraints.model_validate({
+      "sv/1": [
+          {
+              "constraint_id": "DevelopmentFinanceScheme",
+              "constraint_name": "Development Finance Scheme",
+              "value_id": "ODAGrants",
+              "value_name": "Official Development Assistance Grants",
+          },
+          {
+              "constraint_id": "DevelopmentFinanceRecipient",
+              "constraint_name": "Development Finance Recipient",
+              "value_id": "country/GTM",
+              "value_name": "Guatemala",
+          },
+      ],
+      "sv/2": [],
+  })
+
+  assert "sv/1" in constraints and "sv/2" in constraints
+  assert len(constraints["sv/1"]) == 2
+  assert constraints["sv/2"] == []

--- a/datacommons_client/tests/models/test_node_models.py
+++ b/datacommons_client/tests/models/test_node_models.py
@@ -115,17 +115,17 @@ def test_properties_model_validation_empty():
 def test_statvarconstraint_model_validation():
   """Test StatVarConstraint.model_validate parses data correctly."""
   data = {
-      "constraint_id": "DevelopmentFinanceScheme",
-      "constraint_name": "Development Finance Scheme",
-      "value_id": "ODAGrants",
-      "value_name": "Official Development Assistance Grants",
+      "constraintId": "DevelopmentFinanceScheme",
+      "constraintName": "Development Finance Scheme",
+      "valueId": "ODAGrants",
+      "valueName": "Official Development Assistance Grants",
   }
   constraint = StatVarConstraint.model_validate(data)
 
-  assert constraint.constraint_id == "DevelopmentFinanceScheme"
-  assert constraint.constraint_name == "Development Finance Scheme"
-  assert constraint.value_id == "ODAGrants"
-  assert constraint.value_name == "Official Development Assistance Grants"
+  assert constraint.constraintId == "DevelopmentFinanceScheme"
+  assert constraint.constraintName == "Development Finance Scheme"
+  assert constraint.valueId == "ODAGrants"
+  assert constraint.valueName == "Official Development Assistance Grants"
 
 
 def test_statvarconstraints_model_validation():
@@ -133,16 +133,16 @@ def test_statvarconstraints_model_validation():
   constraints = StatVarConstraints.model_validate({
       "sv/1": [
           {
-              "constraint_id": "DevelopmentFinanceScheme",
-              "constraint_name": "Development Finance Scheme",
-              "value_id": "ODAGrants",
-              "value_name": "Official Development Assistance Grants",
+              "constraintId": "DevelopmentFinanceScheme",
+              "constraintName": "Development Finance Scheme",
+              "valueId": "ODAGrants",
+              "valueName": "Official Development Assistance Grants",
           },
           {
-              "constraint_id": "DevelopmentFinanceRecipient",
-              "constraint_name": "Development Finance Recipient",
-              "value_id": "country/GTM",
-              "value_name": "Guatemala",
+              "constraintId": "DevelopmentFinanceRecipient",
+              "constraintName": "Development Finance Recipient",
+              "valueId": "country/GTM",
+              "valueName": "Guatemala",
           },
       ],
       "sv/2": [],

--- a/datacommons_client/tests/test_client.py
+++ b/datacommons_client/tests/test_client.py
@@ -10,6 +10,8 @@ from datacommons_client.endpoints.node import NodeEndpoint
 from datacommons_client.endpoints.observation import ObservationEndpoint
 from datacommons_client.endpoints.resolve import ResolveEndpoint
 from datacommons_client.models.node import Name
+from datacommons_client.models.node import StatVarConstraint
+from datacommons_client.models.node import StatVarConstraints
 from datacommons_client.models.observation import ObservationRecord
 from datacommons_client.models.observation import ObservationRecords
 from datacommons_client.utils.error_handling import NoDataForPropertyError
@@ -209,6 +211,72 @@ def test_observations_dataframe_returns_dataframe_with_expected_columns(
   assert df.iloc[1]["variable_name"] == "Variable Two"
   assert df.iloc[1]["value"] == 200
   assert df.iloc[1]["unit"] == "unit2"
+
+
+def test_observations_dataframe_includes_constraints_metadata(mock_client):
+  """When include_constraints_metadata=True, DataFrame includes constraint columns."""
+  # Two observations with different variables
+  mock_client.observation.fetch_observations_by_entity_dcid.return_value.to_observation_records.return_value = ObservationRecords.model_validate(
+      [
+          {
+              "date": "2021",
+              "entity": "geo/1",
+              "variable": "sv/A",
+              "value": 1,
+              "unit": "Count",
+          },
+          {
+              "date": "2021",
+              "entity": "geo/2",
+              "variable": "sv/B",
+              "value": 2,
+              "unit": "Count",
+          },
+      ])
+
+  # Avoid name lookups
+  mock_client.node.fetch_entity_names = MagicMock(return_value={})
+
+  mock_client.node.fetch_statvar_constraints = MagicMock(
+      return_value=StatVarConstraints.model_validate({
+          "sv/A": [
+              StatVarConstraint(
+                  constraint_id="DevelopmentFinanceScheme",
+                  constraint_name="Development Finance Scheme",
+                  value_id="ODAGrants",
+                  value_name="Official Development Assistance Grants",
+              )
+          ],
+          "sv/B": [
+              StatVarConstraint(
+                  constraint_id="sex",
+                  constraint_name="Sex",
+                  value_id="Female",
+                  value_name="Female",
+              )
+          ],
+      }))
+
+  df = mock_client.observations_dataframe(
+      variable_dcids=["sv/A", "sv/B"],
+      date="2021",
+      entity_dcids=["geo/1", "geo/2"],
+      include_constraints_metadata=True,
+  )
+
+  # Check presence and correctness of constraint columns
+  assert "DevelopmentFinanceScheme" in df.columns
+  assert "DevelopmentFinanceScheme_name" in df.columns
+  assert "sex" in df.columns and "sex_name" in df.columns
+
+  row_a = df[df["variable"] == "sv/A"].iloc[0]
+  assert row_a["DevelopmentFinanceScheme"] == "ODAGrants"
+  assert (row_a["DevelopmentFinanceScheme_name"] ==
+          "Official Development Assistance Grants")
+
+  row_b = df[df["variable"] == "sv/B"].iloc[0]
+  assert row_b["sex"] == "Female"
+  assert row_b["sex_name"] == "Female"
 
 
 @patch(

--- a/datacommons_client/tests/test_client.py
+++ b/datacommons_client/tests/test_client.py
@@ -241,18 +241,18 @@ def test_observations_dataframe_includes_constraints_metadata(mock_client):
       return_value=StatVarConstraints.model_validate({
           "sv/A": [
               StatVarConstraint(
-                  constraint_id="DevelopmentFinanceScheme",
-                  constraint_name="Development Finance Scheme",
-                  value_id="ODAGrants",
-                  value_name="Official Development Assistance Grants",
+                  constraintId="DevelopmentFinanceScheme",
+                  constraintName="Development Finance Scheme",
+                  valueId="ODAGrants",
+                  valueName="Official Development Assistance Grants",
               )
           ],
           "sv/B": [
               StatVarConstraint(
-                  constraint_id="sex",
-                  constraint_name="Sex",
-                  value_id="Female",
-                  value_name="Female",
+                  constraintId="sex",
+                  constraintName="Sex",
+                  valueId="Female",
+                  valueName="Female",
               )
           ],
       }))

--- a/datacommons_client/tests/test_dataframes.py
+++ b/datacommons_client/tests/test_dataframes.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from datacommons_client.endpoints.node import NodeEndpoint
+from datacommons_client.models.node import StatVarConstraint
+from datacommons_client.models.node import StatVarConstraints
+from datacommons_client.utils.dataframes import add_property_constraints_to_observations_dataframe
+
+
+def test_add_property_constraints_to_observations_dataframe_adds_columns():
+  """Adds constraint id and name columns based on statvar metadata."""
+  # Input observations
+  df = pd.DataFrame([
+      {
+          "date": "2020",
+          "entity": "geo/1",
+          "variable": "sv/A",
+          "value": 10,
+          "unit": "Count",
+      },
+      {
+          "date": "2020",
+          "entity": "geo/2",
+          "variable": "sv/B",
+          "value": 20,
+          "unit": "Count",
+      },
+  ])
+
+  endpoint = MagicMock(spec=NodeEndpoint)
+
+  endpoint.fetch_statvar_constraints.return_value = StatVarConstraints.model_validate(
+      {
+          "sv/A": [
+              StatVarConstraint(
+                  constraint_id="DevelopmentFinanceScheme",
+                  constraint_name="Development Finance Scheme",
+                  value_id="ODAGrants",
+                  value_name="Official Development Assistance Grants",
+              ),
+              StatVarConstraint(
+                  constraint_id="DevelopmentFinanceRecipient",
+                  constraint_name="Development Finance Recipient",
+                  value_id="country/GTM",
+                  value_name="Guatemala",
+              ),
+          ],
+          "sv/B": [
+              StatVarConstraint(
+                  constraint_id="sex",
+                  constraint_name="Sex",
+                  value_id="Female",
+                  value_name="Female",
+              )
+          ],
+      })
+
+  out = add_property_constraints_to_observations_dataframe(endpoint=endpoint,
+                                                           observations_df=df)
+
+  # Columns for constraints should be present and filled per variable
+  assert "DevelopmentFinanceScheme" in out.columns
+  assert "DevelopmentFinanceScheme_name" in out.columns
+  assert ("DevelopmentFinanceRecipient" in out.columns and
+          "DevelopmentFinanceRecipient_name" in out.columns)
+  assert "sex" in out.columns and "sex_name" in out.columns
+
+  # Row-wise checks
+  row_a = out[out["variable"] == "sv/A"].iloc[0]
+  assert row_a["DevelopmentFinanceScheme"] == "ODAGrants"
+  assert row_a[
+      "DevelopmentFinanceScheme_name"] == "Official Development Assistance Grants"
+  assert row_a["DevelopmentFinanceRecipient"] == "country/GTM"
+  assert row_a["DevelopmentFinanceRecipient_name"] == "Guatemala"
+
+  row_b = out[out["variable"] == "sv/B"].iloc[0]
+  assert row_b["sex"] == "Female"
+  assert row_b["sex_name"] == "Female"
+
+
+def test_add_property_constraints_to_observations_dataframe_empty():
+  """Empty DataFrame returns unchanged."""
+  endpoint = MagicMock(spec=NodeEndpoint)
+  empty_df = pd.DataFrame([])
+  out = add_property_constraints_to_observations_dataframe(
+      endpoint=endpoint, observations_df=empty_df)
+  assert out.empty

--- a/datacommons_client/tests/test_dataframes.py
+++ b/datacommons_client/tests/test_dataframes.py
@@ -34,24 +34,24 @@ def test_add_property_constraints_to_observations_dataframe_adds_columns():
       {
           "sv/A": [
               StatVarConstraint(
-                  constraint_id="DevelopmentFinanceScheme",
-                  constraint_name="Development Finance Scheme",
-                  value_id="ODAGrants",
-                  value_name="Official Development Assistance Grants",
+                  constraintId="DevelopmentFinanceScheme",
+                  constraintName="Development Finance Scheme",
+                  valueId="ODAGrants",
+                  valueName="Official Development Assistance Grants",
               ),
               StatVarConstraint(
-                  constraint_id="DevelopmentFinanceRecipient",
-                  constraint_name="Development Finance Recipient",
-                  value_id="country/GTM",
-                  value_name="Guatemala",
+                  constraintId="DevelopmentFinanceRecipient",
+                  constraintName="Development Finance Recipient",
+                  valueId="country/GTM",
+                  valueName="Guatemala",
               ),
           ],
           "sv/B": [
               StatVarConstraint(
-                  constraint_id="sex",
-                  constraint_name="Sex",
-                  value_id="Female",
-                  value_name="Female",
+                  constraintId="sex",
+                  constraintName="Sex",
+                  valueId="Female",
+                  valueName="Female",
               )
           ],
       })

--- a/datacommons_client/utils/dataframes.py
+++ b/datacommons_client/utils/dataframes.py
@@ -59,3 +59,37 @@ def add_entity_names_to_observations_dataframe(
       )
 
   return observations_df
+
+
+@requires_pandas
+def add_property_constraints_to_observations_dataframe(
+    endpoint: NodeEndpoint,
+    observations_df: "pd.DataFrame",  # type: ignore[reportInvalidTypeForm]
+) -> "pd.DataFrame":  # type: ignore[reportInvalidTypeForm]
+  """
+    Adds property constraint dcids and names to the observations DataFrame.
+
+    Args:
+        endpoint (NodeEndpoint): The NodeEndpoint instance for fetching entity names.
+        observations_df (dict): The DataFrame containing observations.
+    """
+
+  # Guard against empty DataFrame
+  if observations_df.empty:
+    return observations_df
+
+  # Get constraints
+  constraints_data = endpoint.fetch_statvar_constraints(
+      variable_dcids=observations_df.variable.unique().tolist())
+
+  for statvar, constraints in constraints_data.items():
+    for constraint in constraints:
+      # Fill the columns with the corresponding values
+      observations_df.loc[observations_df.variable == statvar,
+                          constraint.constraint_id] = constraint.value_id
+
+      observations_df.loc[observations_df.variable == statvar,
+                          constraint.constraint_id +
+                          "_name"] = constraint.value_name
+
+  return observations_df

--- a/datacommons_client/utils/dataframes.py
+++ b/datacommons_client/utils/dataframes.py
@@ -86,10 +86,10 @@ def add_property_constraints_to_observations_dataframe(
     for constraint in constraints:
       # Fill the columns with the corresponding values
       observations_df.loc[observations_df.variable == statvar,
-                          constraint.constraint_id] = constraint.value_id
+                          constraint.constraintId] = constraint.valueId
 
       observations_df.loc[observations_df.variable == statvar,
-                          constraint.constraint_id +
-                          "_name"] = constraint.value_name
+                          constraint.constraintId +
+                          "_name"] = constraint.valueName
 
   return observations_df


### PR DESCRIPTION
This pull request adds support for including constraint property metadata in statistical observation DataFrames and introduces new models and endpoints for handling constraint properties associated with statistical variables. The changes are primarily focused on enhancing the ability to fetch and display constraint information related to statistical variables in the DataFrame output.

**Enhancements to DataFrame constraint metadata:**

* Added an `include_constraints_metadata` parameter to the `observations_dataframe` method in `client.py`, allowing users to optionally include constraint property DCIDs and names in the returned DataFrame. [[1]](diffhunk://#diff-48df5d9f40a2510bb88db839d37e078f502c9a9fbcb3aaaf694e74b6a33be19bR125) [[2]](diffhunk://#diff-48df5d9f40a2510bb88db839d37e078f502c9a9fbcb3aaaf694e74b6a33be19bR145-R146) [[3]](diffhunk://#diff-48df5d9f40a2510bb88db839d37e078f502c9a9fbcb3aaaf694e74b6a33be19bR202-R207)
* Implemented the `add_property_constraints_to_observations_dataframe` utility function, which populates constraint property DCIDs and names for each observation in the DataFrame.

**New models and endpoint methods for constraint properties:**

* Introduced `StatVarConstraint` and `StatVarConstraints` models in `models/node.py` to represent constraint properties and their values for statistical variables.
* Added methods to `NodeEndpoint` in `endpoints/node.py` for fetching constraint property DCIDs and names (`_fetch_property_id_names`) and for retrieving constraint property/value pairs for statistical variables (`fetch_statvar_constraints`).

**Internal import updates:**

* Updated imports in `client.py` and `endpoints/node.py` to include new utility functions and models required for constraint property handling. [[1]](diffhunk://#diff-48df5d9f40a2510bb88db839d37e078f502c9a9fbcb3aaaf694e74b6a33be19bR9) [[2]](diffhunk://#diff-eaab813e8b788ec171f0c4febfe77941b0a7cc1ee7d492460b10dd26a947dbecR14-R15)